### PR TITLE
method saveAll handles the flase from getDirty

### DIFF
--- a/src/Sigep/EloquentEnhancements/Traits/SaveAll.php
+++ b/src/Sigep/EloquentEnhancements/Traits/SaveAll.php
@@ -107,7 +107,10 @@ trait SaveAll
         }
 
         if (!$skipUpdate) {
-            if ($this->__handleValidator($options, $path) === false || $this->save() === false) {
+            if ($this->__handleValidator($options, $path) === false) {
+                return false;
+            }
+            if (($this->save() === false) && ($this->isDirty())) {
                 return false;
             }
         }


### PR DESCRIPTION
Updates the saveAll method to keep saving the relational data if the object is not dirty and, therefore, was not save by Eloquent.
