### PR TITLE
Fixed declaration of save method

### DIFF
--- a/src/Sigep/EloquentEnhancements/Traits/SaveAll.php
+++ b/src/Sigep/EloquentEnhancements/Traits/SaveAll.php
@@ -23,7 +23,7 @@ trait SaveAll
      * @param array $options
      * @return mixed
      */
-    abstract function save(array $options);
+    abstract function save(array $options = []);
 
     /**
      * Get the default foreign key name for the model.


### PR DESCRIPTION
Fixed declaration of Sigep\EloquentEnhancements\Traits\SaveAll::save(array $options) to be compatible with Illuminate\Database\Eloquent\Model::save(array $options = Array)